### PR TITLE
fix compilation errors on mac os

### DIFF
--- a/src/gpx/gpx.h
+++ b/src/gpx/gpx.h
@@ -40,6 +40,9 @@ extern "C" {
 #if defined(SERIAL_SUPPORT)
 #if !defined(_WIN32) && !defined(_WIN64)
 #include <termios.h>
+#if defined(__APPLE__)
+#include "winsio.h"
+#endif
 #else
 #include "winsio.h"
 #endif

--- a/src/gpx/winsio.h
+++ b/src/gpx/winsio.h
@@ -37,7 +37,7 @@
 #define B57600 57600
 #define B115200 115200
 
-#if !defined(SPEED_T_DEFINED)
+#if !defined(SPEED_T_DEFINED) && !defined(__APPLE__)
 typedef long speed_t;
 #define SPEED_T_DEFINED
 #endif


### PR DESCRIPTION
On macOS the baud rate defines are missing in the termios.h header. To solve this, include the already existing replacements for the defines from winsio.h. This allows GPX to build on macOS.